### PR TITLE
Load JS when document is ready

### DIFF
--- a/index.html
+++ b/index.html
@@ -341,6 +341,7 @@
 
     <script type="text/javascript">
         // Last update
+        $( document ).ready(function() {
         fetch("https://api.github.com/repos/HeRTA/FRBSTATS/commits?path=catalogue.csv&page=1&per_page=1")
             .then(response => response.text())
             .then(jsonString => {
@@ -448,6 +449,7 @@
             document.getElementById("coverage").innerHTML = coverage + "%";
             $('#coverage_progressbar').attr('aria-valuenow', coverage).css('width', coverage+'%');
         })
+    });
     </script>
     <!-- Bootstrap core JavaScript-->
     <script src="vendor/jquery/jquery.min.js"></script>


### PR DESCRIPTION
It's better to load JS when html is loaded. Else you might run into issues with the DOM tree. 